### PR TITLE
Apply changes from PR #82 to the develop [default] branch (aid on solution for fibercrypto/skywallet-mcu#342)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 .DEFAULT_GOAL := help
 .PHONY: help all clean install
 .PHONY: build-go build-js build-c build-py
-.PHONY: install-deps-go install-deps-js install-deps-nanopb install-protoc
+.PHONY: install-deps-go install-deps-js install-deps-nanopb
+.PHONY: install-protoc install-protoc-linux install-protoc-osx install-protoc-win32
 .PHONY: clean-go clean-js clean-c clean-py
 
 REPO_ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,8 @@ clean-c: clean-py
 		$$( find $(OUT_C) -name '*.d' ) \
 		$$( find $(OUT_C) -name '*.i' ) \
 		$$( find $(OUT_C) -name '*.s' ) \
-		$$( find $(OUT_C) -name '*.o' )
+		$$( find $(OUT_C) -name '*.o' ) \
+		/usr/local/bin/protoc*
 
 #----------------
 # Python with nanopb

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@
 REPO_ROOT := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 
 UNAME_S  = $(shell uname -s)
-PYTHON  ?= python
+PYTHON  ?= python3
 PIP     ?= pip3
 PIPARGS ?=
 GOPATH  ?= $(HOME)/go

--- a/Makefile
+++ b/Makefile
@@ -80,9 +80,9 @@ clean: clean-go clean-js clean-c clean-py ## Delete temporary and output files
 		$$( find . -name '*.swo' ) \
 		$$( find . -name '*.orig' )
 
-install-protoc-linux: install-protoc
+install-protoc-linux: /usr/local/bin/protoc
 
-install-protoc-osx: install-protoc
+install-protoc-osx: /usr/local/bin/protoc
 
 install-protoc-win32: /usr/local/bin/protoc.exe
 
@@ -172,8 +172,8 @@ clean-c: clean-py
 		$$( find $(OUT_C) -name '*.d' ) \
 		$$( find $(OUT_C) -name '*.i' ) \
 		$$( find $(OUT_C) -name '*.s' ) \
-		$$( find $(OUT_C) -name '*.o' ) \
-		/usr/local/bin/protoc*
+		$$( find $(OUT_C) -name '*.o' )
+	sudo rm -f /usr/local/bin/protoc* || exit 0
 
 #----------------
 # Python with nanopb


### PR DESCRIPTION
Fixes #83 changes was wrongly applied to master when the default branch is develop, develop is the one used on fibercrypto/skywallet-mcu and this will aid to fix fibercrypto/skywallet-mcu#342 

Changes:
- Forces Python3 (python2 deprecation and fail)
- Improve OS detection by adding windows under MSYS2
- Introduce the windows build for the target build-c (under MSYS2) see fibercrypto/skywallet-mcu#342 for details
- Add the clean options for the windows build
- Touch phony targets, etc.

Does this change need to mentioned in CHANGELOG.md?
No

Related issues:
PR fibercrypto/skywallet-mcu#342
PR fibercrypto/skywallet-protob#81

